### PR TITLE
fix problem with release version and unfinished init of i2c

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -97,7 +97,8 @@ pub fn init(i2c: &'static mut i2c::I2c) -> I2C {
                     r.set_nostretch(false); // clock_stretching_disable
                     r.set_pe(true); // peripheral_enable
                 });
-
+    // wait that init can finish
+    ::system_clock::wait(50);
     I2C(i2c)
 }
 


### PR DESCRIPTION
When in release mode often the init of the i2c was not finished early enough.
This could result in following code accessing the i2c to crash.
A small wait can help to wait for the init to finish before going on.
(At least on my tests this wait was always sufficient, no more panics)