### PR TITLE
Fix register_owned bug: 

### DIFF
--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -360,8 +360,9 @@ impl<'a> InterruptTable<'a> {
         // transmute::<Box<FnMut()>, Box<FnMut() + 'static + Send>> is safe, because of the drop implementation of InterruptTable ('static is not needed for closure)
         // and alway only one isr can access the data (Send is not needed for closure)
         let isr = unsafe {
+            let parameter = &mut *(self.data[irq as usize] as *mut T);
             transmute::<Box<FnMut()>, Box<FnMut() + 'static + Send>>(Box::new(
-                || { isr(&mut *(self.data[irq as usize] as *mut T)); },
+                move || { isr(parameter); },
             ))
         };
         let interrupt_handle = self.insert_boxed_isr(irq, isr)?;


### PR DESCRIPTION
the isr must be a move closure to ensure that the used variables live long enough.