### PR TITLE
Make FontRenderer public

### DIFF
--- a/src/lcd/mod.rs
+++ b/src/lcd/mod.rs
@@ -3,11 +3,11 @@
 pub use self::color::Color;
 pub use self::init::init;
 pub use self::stdout::init as init_stdout;
+pub use self::font::FontRenderer;
 
 use board::ltdc::Ltdc;
 use embedded::interfaces::gpio::OutputPin;
 use core::{fmt, ptr};
-use self::font::FontRenderer;
 
 #[macro_use]
 pub mod stdout;


### PR DESCRIPTION
Looks as if the previous change wasn't sufficient to actually access FontRenderer from outside.