### PR TITLE
gdb.sh detect MacOS (darwin)

### DIFF
--- a/gdb.sh
+++ b/gdb.sh
@@ -5,4 +5,10 @@ set -e
 echo "Please run 'st-util' in another terminal window (you might need sudo)"
 echo ""
 
-arm-none-eabi-gdb -iex 'add-auto-load-safe-path .' -ex "tar ext :4242" -ex "load-reset" target/stm32f7/debug/stm32f7_discovery
+# https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    # Linux*)     machine=Linux;;
+    Darwin*)    arm-none-eabi-gdb-py -iex 'add-auto-load-safe-path .' -ex "tar ext :4242" -ex "load-reset" target/stm32f7/debug/stm32f7_discovery;;
+    *)          arm-none-eabi-gdb -iex 'add-auto-load-safe-path .' -ex "tar ext :4242" -ex "load-reset" target/stm32f7/debug/stm32f7_discovery
+esac


### PR DESCRIPTION
run 'arm-none-eabi-gdb-py' instead of 'arm-none-eabi-gdb' on Mac (darwin)