### PR TITLE
Extract ETH_ADDR and IP_ADDR constants from ethernet module

### DIFF
--- a/src/lcd/color.rs
+++ b/src/lcd/color.rs
@@ -69,14 +69,15 @@ impl Color {
         }
     }
     
-    pub fn from_hsv(hue: i32, saturation: f32, value: f32) -> lcd::Color {
+    pub fn from_hsv(hue: i32, saturation: f32, value: f32) -> Color {
         let mut h = hue % 360;
         if h < 0 {
             h += 360;
         }
 
         let c = value * saturation;
-        let x = c * (1f32 - abs((h % 120) as f32 / 60f32 - 1f32));
+        let x = (h as i32 % 120) as f32 / 60f32 - 1f32;
+        let x = c * (1f32 - if x < 0f32 { -x } else { x });
         let m = value - c;
 
         let mut rgb = (0f32, 0f32, 0f32);
@@ -104,7 +105,7 @@ impl Color {
         rgb.1 += m;
         rgb.2 += m;
 
-        lcd::Color::rgb(
+        Color::rgb(
                 (255f32 * rgb.0) as u8,
                 (255f32 * rgb.1) as u8,
                 (255f32 * rgb.2) as u8)

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,14 @@ extern crate smoltcp;
 
 // hardware register structs with accessor methods
 use stm32f7::{audio, board, embedded, ethernet, lcd, sdram, system_clock, touch, i2c};
-use stm32f7::ethernet::IP_ADDR;
 use smoltcp::socket::{Socket, SocketSet, TcpSocket, TcpSocketBuffer};
 use smoltcp::socket::{UdpSocket, UdpPacketMetadata, UdpSocketBuffer};
-use smoltcp::wire::{IpEndpoint, IpAddress};
+use smoltcp::wire::{IpEndpoint, IpAddress, EthernetAddress, Ipv4Address};
 use smoltcp::time::Instant;
 use alloc::Vec;
+
+pub const ETH_ADDR: EthernetAddress = EthernetAddress([0x00, 0x08, 0xdc, 0xab, 0xcd, 0xef]);
+pub const IP_ADDR: Ipv4Address = Ipv4Address([141, 52, 46, 198]);
 
 #[no_mangle]
 pub unsafe extern "C" fn reset() -> ! {
@@ -168,7 +170,8 @@ fn main(hw: board::Hardware) -> ! {
         &mut gpio,
         ethernet_mac,
         ethernet_dma,
-    ).map(|device| device.into_interface());
+        ETH_ADDR,
+    ).map(|device| device.into_interface(IP_ADDR));
     if let Err(e) = ethernet_interface {
         println!("ethernet init failed: {:?}", e);
     };


### PR DESCRIPTION
So that we can change those addresses in projects depending on stm32f7-discovery.