### PR TITLE
Store singleton directly in I2C type to take ownership

### DIFF
--- a/src/bin/async-await.rs
+++ b/src/bin/async-await.rs
@@ -21,7 +21,6 @@ extern crate futures;
 extern crate smoltcp;
 extern crate spin;
 
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use alloc_cortex_m::CortexMHeap;
@@ -43,6 +42,7 @@ use smoltcp::{
 };
 use stm32f7::stm32f7x6::{
     CorePeripherals, Interrupt, Peripherals, ETHERNET_DMA, ETHERNET_MAC, RCC, SAI2, SYSCFG,
+    self as device,
 };
 use stm32f7_discovery::{
     ethernet,
@@ -135,7 +135,7 @@ fn run() -> ! {
     // example allocation
     let _xs = vec![1, 2, 3];
 
-    let mut i2c_3 = init::init_i2c_3(Box::leak(Box::new(peripherals.I2C3)), &mut rcc);
+    let mut i2c_3 = init::init_i2c_3(peripherals.I2C3, &mut rcc);
     i2c_3.test_1();
     i2c_3.test_2();
 
@@ -340,7 +340,7 @@ where
     F: Framebuffer,
 {
     touch_int_stream: S,
-    i2c_3_mutex: Arc<FutureMutex<I2C<'static>>>,
+    i2c_3_mutex: Arc<FutureMutex<I2C<device::I2C3>>>,
     layer_mutex: Arc<FutureMutex<Layer<F>>>,
 }
 

--- a/src/bin/polling.rs
+++ b/src/bin/polling.rs
@@ -32,7 +32,7 @@ use smoltcp::{
     wire::{EthernetAddress, IpEndpoint, Ipv4Address, IpCidr},
     dhcp::Dhcpv4Client,
 };
-use stm32f7::stm32f7x6::{CorePeripherals, Interrupt, Peripherals};
+use stm32f7::stm32f7x6::{self as device, CorePeripherals, Interrupt, Peripherals};
 use stm32f7_discovery::{
     ethernet,
     gpio::{GpioPort, InputPin, OutputPin},
@@ -111,7 +111,7 @@ fn main() -> ! {
 
     let _xs = vec![1, 2, 3];
 
-    let mut i2c_3 = init::init_i2c_3(&peripherals.I2C3, &mut rcc);
+    let mut i2c_3 = init::init_i2c_3(peripherals.I2C3, &mut rcc);
     i2c_3.test_1();
     i2c_3.test_2();
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1,9 +1,9 @@
 //! Provides various hardware initialization functions.
 
-use crate::i2c::{self, I2C};
+use crate::i2c::{self, I2C, I2cTrait};
 use crate::lcd::{self, Lcd};
 use crate::system_clock;
-use stm32f7::stm32f7x6::{i2c1, FLASH, FMC, LTDC, PWR, RCC, SAI2, SYST};
+use stm32f7::stm32f7x6::{self as device, i2c1, FLASH, FMC, LTDC, PWR, RCC, SAI2, SYST};
 
 pub use self::pins::init as pins;
 
@@ -298,7 +298,7 @@ pub fn init_lcd<'a>(ltdc: &'a mut LTDC, rcc: &mut RCC) -> Lcd<'a> {
 /// Initializes the I2C3 bus.
 ///
 /// This function is equivalent to [`i2c::init`](crate::i2c::init).
-pub fn init_i2c_3<'a>(i2c: &'a i2c1::RegisterBlock, rcc: &mut RCC) -> I2C<'a> {
+pub fn init_i2c_3(i2c: device::I2C3, rcc: &mut RCC) -> I2C<device::I2C3> {
     i2c::init(i2c, rcc)
 }
 
@@ -525,7 +525,7 @@ const WM8994_ADDRESS: i2c::Address = i2c::Address::bits_7(0b0011010);
 /// Initializes the WM8994 audio controller.
 ///
 /// Required for audio input.
-pub fn init_wm8994(i2c_3: &mut i2c::I2C) -> Result<(), i2c::Error> {
+pub fn init_wm8994(i2c_3: &mut i2c::I2C<device::I2C3>) -> Result<(), i2c::Error> {
     i2c_3.connect::<u16, _>(WM8994_ADDRESS, |mut conn| {
         // read and check device family ID
         assert_eq!(conn.read(0).ok(), Some(0x8994));

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -2,6 +2,7 @@
 
 use crate::i2c::{self, I2C};
 use arrayvec::ArrayVec;
+use stm32f7::stm32f7x6 as device;
 
 const FT5336_ADDRESS: i2c::Address = i2c::Address::bits_7(0b0111000);
 const FT5336_FAMILY_ID_REGISTER: u8 = 0xA8;
@@ -11,7 +12,7 @@ const FT5336_STATUS_REGISTER: u8 = 0x02;
 const FT5336_DATA_REGISTERS: [u8; 5] = [0x03, 0x09, 0x0F, 0x15, 0x1B];
 
 /// Checks the whether the device familiy ID register contains the expected value.
-pub fn check_family_id(i2c_3: &mut I2C) -> Result<(), i2c::Error> {
+pub fn check_family_id(i2c_3: &mut I2C<device::I2C3>) -> Result<(), i2c::Error> {
     i2c_3.connect::<u8, _>(FT5336_ADDRESS, |mut conn| {
         // read and check device family ID
         assert_eq!(conn.read(FT5336_FAMILY_ID_REGISTER).ok(), Some(0x51));
@@ -27,7 +28,7 @@ pub struct Touch {
 }
 
 /// Returns a list of active touch points.
-pub fn touches(i2c_3: &mut I2C) -> Result<ArrayVec<[Touch; 5]>, i2c::Error> {
+pub fn touches(i2c_3: &mut I2C<device::I2C3>) -> Result<ArrayVec<[Touch; 5]>, i2c::Error> {
     let mut touches = ArrayVec::new();
     i2c_3.connect::<u8, _>(FT5336_ADDRESS, |mut conn| {
         let status = conn.read(FT5336_STATUS_REGISTER)?;


### PR DESCRIPTION
Make the I2C type generic over a new I2cTrait so that all I2C busses are supported.