### PR TITLE
Refactor GpioPort to use the zero-sized GPIO* types directly

### DIFF
--- a/src/bin/async-await.rs
+++ b/src/bin/async-await.rs
@@ -91,17 +91,17 @@ fn run() -> ! {
     init::enable_gpio_ports(&mut rcc);
     init::enable_syscfg(&mut rcc);
 
-    let gpio_a = GpioPort::new_a(&peripherals.GPIOA);
-    let gpio_b = GpioPort::new_b(&peripherals.GPIOB);
-    let gpio_c = GpioPort::new(&peripherals.GPIOC);
-    let gpio_d = GpioPort::new(&peripherals.GPIOD);
-    let gpio_e = GpioPort::new(&peripherals.GPIOE);
-    let gpio_f = GpioPort::new(&peripherals.GPIOF);
-    let gpio_g = GpioPort::new(&peripherals.GPIOG);
-    let gpio_h = GpioPort::new(&peripherals.GPIOH);
-    let gpio_i = GpioPort::new(&peripherals.GPIOI);
-    let gpio_j = GpioPort::new(&peripherals.GPIOJ);
-    let gpio_k = GpioPort::new(&peripherals.GPIOK);
+    let gpio_a = GpioPort::new(peripherals.GPIOA);
+    let gpio_b = GpioPort::new(peripherals.GPIOB);
+    let gpio_c = GpioPort::new(peripherals.GPIOC);
+    let gpio_d = GpioPort::new(peripherals.GPIOD);
+    let gpio_e = GpioPort::new(peripherals.GPIOE);
+    let gpio_f = GpioPort::new(peripherals.GPIOF);
+    let gpio_g = GpioPort::new(peripherals.GPIOG);
+    let gpio_h = GpioPort::new(peripherals.GPIOH);
+    let gpio_i = GpioPort::new(peripherals.GPIOI);
+    let gpio_j = GpioPort::new(peripherals.GPIOJ);
+    let gpio_k = GpioPort::new(peripherals.GPIOK);
     let mut pins = init::pins(
         gpio_a, gpio_b, gpio_c, gpio_d, gpio_e, gpio_f, gpio_g, gpio_h, gpio_i, gpio_j, gpio_k,
     );

--- a/src/bin/polling.rs
+++ b/src/bin/polling.rs
@@ -73,17 +73,17 @@ fn main() -> ! {
     init::init_system_clock_216mhz(&mut rcc, &mut pwr, &mut flash);
     init::enable_gpio_ports(&mut rcc);
 
-    let gpio_a = GpioPort::new_a(&peripherals.GPIOA);
-    let gpio_b = GpioPort::new_b(&peripherals.GPIOB);
-    let gpio_c = GpioPort::new(&peripherals.GPIOC);
-    let gpio_d = GpioPort::new(&peripherals.GPIOD);
-    let gpio_e = GpioPort::new(&peripherals.GPIOE);
-    let gpio_f = GpioPort::new(&peripherals.GPIOF);
-    let gpio_g = GpioPort::new(&peripherals.GPIOG);
-    let gpio_h = GpioPort::new(&peripherals.GPIOH);
-    let gpio_i = GpioPort::new(&peripherals.GPIOI);
-    let gpio_j = GpioPort::new(&peripherals.GPIOJ);
-    let gpio_k = GpioPort::new(&peripherals.GPIOK);
+    let gpio_a = GpioPort::new(peripherals.GPIOA);
+    let gpio_b = GpioPort::new(peripherals.GPIOB);
+    let gpio_c = GpioPort::new(peripherals.GPIOC);
+    let gpio_d = GpioPort::new(peripherals.GPIOD);
+    let gpio_e = GpioPort::new(peripherals.GPIOE);
+    let gpio_f = GpioPort::new(peripherals.GPIOF);
+    let gpio_g = GpioPort::new(peripherals.GPIOG);
+    let gpio_h = GpioPort::new(peripherals.GPIOH);
+    let gpio_i = GpioPort::new(peripherals.GPIOI);
+    let gpio_j = GpioPort::new(peripherals.GPIOJ);
+    let gpio_k = GpioPort::new(peripherals.GPIOK);
     let mut pins = init::pins(
         gpio_a, gpio_b, gpio_c, gpio_d, gpio_e, gpio_f, gpio_g, gpio_h, gpio_i, gpio_j, gpio_k,
     );

--- a/src/init/pins.rs
+++ b/src/init/pins.rs
@@ -1,7 +1,9 @@
 use self::pin_wrapper::PortPins;
 use crate::gpio::{
-    AlternateFunction, GpioPort, InputPin, OutputPin, OutputSpeed, OutputType, RegisterBlockA,
-    RegisterBlockB, RegisterBlockD, Resistor,
+    AlternateFunction, GpioPort, InputPin, OutputPin, OutputSpeed, OutputType, Resistor,
+};
+use stm32f7::stm32f7x6::{
+    GPIOA, GPIOB, GPIOC, GPIOD, GPIOE, GPIOF, GPIOG, GPIOH, GPIOI, GPIOJ, GPIOK,
 };
 
 /// This struct contains special PIO pins.
@@ -34,17 +36,17 @@ pub struct Pins<
 /// This function uses Rust's ownership mechanism internally to report duplicate mappings
 /// at compile time.
 pub fn init<'a>(
-    mut gpio_a: GpioPort<RegisterBlockA<'a>>,
-    mut gpio_b: GpioPort<RegisterBlockB<'a>>,
-    mut gpio_c: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_d: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_e: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_f: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_g: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_h: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_i: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_j: GpioPort<RegisterBlockD<'a>>,
-    mut gpio_k: GpioPort<RegisterBlockD<'a>>,
+    mut gpio_a: GpioPort<GPIOA>,
+    mut gpio_b: GpioPort<GPIOB>,
+    mut gpio_c: GpioPort<GPIOC>,
+    mut gpio_d: GpioPort<GPIOD>,
+    mut gpio_e: GpioPort<GPIOE>,
+    mut gpio_f: GpioPort<GPIOF>,
+    mut gpio_g: GpioPort<GPIOG>,
+    mut gpio_h: GpioPort<GPIOH>,
+    mut gpio_i: GpioPort<GPIOI>,
+    mut gpio_j: GpioPort<GPIOJ>,
+    mut gpio_k: GpioPort<GPIOK>,
 ) -> Pins<
     impl OutputPin + 'a,
     impl InputPin + 'a,


### PR DESCRIPTION
cc https://github.com/embed-rs/stm32f7-discovery/issues/72