### PR TITLE
Too many newlines

### DIFF
--- a/examples/lcd.rs
+++ b/examples/lcd.rs
@@ -1,0 +1,133 @@
+#![feature(alloc)]
+#![feature(alloc_error_handler)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::string::String;
+use alloc_cortex_m::CortexMHeap;
+use core::alloc::Layout as AllocLayout;
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use cortex_m::{asm, interrupt, peripheral::NVIC};
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+use cortex_m_semihosting::hio::{self, HStdout};
+use stm32f7::{
+    interrupt,
+    stm32f7x6::{CorePeripherals, Interrupt, Peripherals}
+};
+use stm32f7_discovery::{
+    print, println,
+    gpio::{GpioPort, InputPin, OutputPin},
+    init,
+    lcd,
+};
+
+#[global_allocator]
+static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
+
+const HEAP_SIZE: usize = 50 * 1024; // in bytes
+
+#[entry]
+fn main() -> ! {
+    let core_peripherals = CorePeripherals::take().unwrap();
+    let mut nvic = core_peripherals.NVIC;
+
+    let peripherals = Peripherals::take().unwrap();
+    let mut rcc = peripherals.RCC;
+    let mut pwr = peripherals.PWR;
+    let mut flash = peripherals.FLASH;
+    let mut fmc = peripherals.FMC;
+    let mut ltdc = peripherals.LTDC;
+
+    init::init_system_clock_216mhz(&mut rcc, &mut pwr, &mut flash);
+    init::enable_gpio_ports(&mut rcc);
+
+    let gpio_a = GpioPort::new(peripherals.GPIOA);
+    let gpio_b = GpioPort::new(peripherals.GPIOB);
+    let gpio_c = GpioPort::new(peripherals.GPIOC);
+    let gpio_d = GpioPort::new(peripherals.GPIOD);
+    let gpio_e = GpioPort::new(peripherals.GPIOE);
+    let gpio_f = GpioPort::new(peripherals.GPIOF);
+    let gpio_g = GpioPort::new(peripherals.GPIOG);
+    let gpio_h = GpioPort::new(peripherals.GPIOH);
+    let gpio_i = GpioPort::new(peripherals.GPIOI);
+    let gpio_j = GpioPort::new(peripherals.GPIOJ);
+    let gpio_k = GpioPort::new(peripherals.GPIOK);
+    let mut pins = init::pins(
+        gpio_a, gpio_b, gpio_c, gpio_d, gpio_e, gpio_f, gpio_g, gpio_h, gpio_i, gpio_j, gpio_k,
+    );
+
+    init::init_sdram(&mut rcc, &mut fmc);
+    let mut lcd = init::init_lcd(&mut ltdc, &mut rcc);
+    pins.display_enable.set(true);
+    pins.backlight.set(true);
+
+    let mut layer_1 = lcd.layer_1().unwrap();
+    let mut layer_2 = lcd.layer_2().unwrap();
+
+    layer_1.clear();
+    layer_2.clear();
+    lcd::init_stdout(layer_2);
+
+    println!("Try pressing the blue button one the left side!");
+
+    // Initialize the allocator BEFORE you use it
+    unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
+
+    nvic.enable(Interrupt::EXTI0);
+
+    let mut previous_button_state = pins.button.get();
+    loop {
+        // poll button state
+        let current_button_state = pins.button.get();
+        if current_button_state != previous_button_state {
+            if current_button_state {
+                pins.led.toggle();
+
+                // trigger the `EXTI0` interrupt
+                NVIC::pend(Interrupt::EXTI0);
+            }
+
+            previous_button_state = current_button_state;
+        }
+    }
+}
+
+interrupt!(EXTI0, exti0, state: Option<HStdout> = None);
+
+fn exti0(_state: &mut Option<HStdout>) {
+    println!("Interrupt fired! This means that the button was pressed.");
+    println!("{}", String::from_utf8(vec![b'-'; 60]).unwrap());
+}
+
+#[exception]
+fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("HardFault at {:#?}", ef);
+}
+
+// define what happens in an Out Of Memory (OOM) condition
+#[alloc_error_handler]
+fn rust_oom(_: AllocLayout) -> ! {
+    panic!("out of memory");
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    interrupt::disable();
+
+    if lcd::stdout::is_initialized() {
+        println!("{}", info);
+    }
+
+    if let Ok(mut hstdout) = hio::hstdout() {
+        let _ = writeln!(hstdout, "{}", info);
+    }
+
+    // OK to fire a breakpoint here because we know the microcontroller is connected to a debugger
+    asm::bkpt();
+
+    loop {}
+}

--- a/src/lcd/mod.rs
+++ b/src/lcd/mod.rs
@@ -330,6 +330,9 @@ impl<'a, T: Framebuffer> fmt::Write for TextWriter<'a, T> {
             }
             match c {
                 ' '..='~' => {
+                    if self.x_pos >= WIDTH {
+                        self.newline();
+                    }
                     let rendered = font8x8::BASIC_FONTS
                         .get(c)
                         .expect("character not found in basic font");
@@ -350,9 +353,6 @@ impl<'a, T: Framebuffer> fmt::Write for TextWriter<'a, T> {
                 _ => panic!("unprintable character"),
             }
             self.x_pos += 8;
-            if self.x_pos >= WIDTH {
-                self.newline();
-            }
         }
         Ok(())
     }


### PR DESCRIPTION
After printing a character, the code would previously automatically start
a new line when the right side of the screen was reached.
Thus, printing a newline at the end of a line resulted in two newlines
being printed.

The new code starts a new line only *before* printing non-CRLF
characters.